### PR TITLE
Add a little more padding to delegation amount due to reported failures in Vessel

### DIFF
--- a/src/helpers/broadcast.ts
+++ b/src/helpers/broadcast.ts
@@ -200,7 +200,7 @@ export class BroadcastAPI {
 
             const targetDelegation = sharePrice
                 .convert(creationFee.multiply(modifier * ratio))
-                .add('0.000001 VESTS') // add a tiny buffer since we are trying to hit a moving target
+                .add('0.000002 VESTS') // add a tiny buffer since we are trying to hit a moving target
 
             if (delegation !== undefined && fee === undefined) {
                 delegation = Asset.from(delegation, 'VESTS')


### PR DESCRIPTION
This pull request adds a little padding to the target delegation used in creating new accounts. The reason for this pull request is due to the number of users reporting some failures when creating accounts in Vessel using the dsteem implementation.